### PR TITLE
Add metadata to lang npm package

### DIFF
--- a/packages/lang/package.json
+++ b/packages/lang/package.json
@@ -2,6 +2,12 @@
 	"name": "@braidai/lang",
 	"type": "module",
 	"version": "1.1.0",
+	"license": "ISC",
+	"homepage": "https://github.com/braidnetworks/braidai/tree/main/packages/lang",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/braidnetworks/braidai.git"
+	},
 	"scripts": {
 		"prepare": "rm -rf dist && tsc -b"
 	},


### PR DESCRIPTION
This update the manifest of [`@braidai/lang`](https://www.npmjs.com/package/@braidai/lang) so that it specifies the license (ISC based on [`./LICENSE`](https://github.com/braidnetworks/braidai/blob/d8e6358ee6a5dfe29841f178a6a5b4ddf4662477/LICENSE)), a homepage link (linking directly to the dir of the package in this repo), and a repository link (linking to this git repo).

These changes will add this info to the sidebar at <https://www.npmjs.com/package/@braidai/lang> and make it available in a [standardized format](https://docs.npmjs.com/cli/v11/configuring-npm/package-json) for automated tooling.